### PR TITLE
added get_top_contracts_by_steps function

### DIFF
--- a/database/migrations/004_get_top_contracts_by_steps.up.sql
+++ b/database/migrations/004_get_top_contracts_by_steps.up.sql
@@ -1,0 +1,76 @@
+BEGIN;
+
+DROP FUNCTION IF EXISTS starkflare_api.get_top_contracts_by_steps();
+
+CREATE OR REPLACE FUNCTION starkflare_api.get_top_contracts_by_steps()
+RETURNS TABLE (
+    contract_hash VARCHAR(66),
+    contract_steps BIGINT,
+    contract_steps_percentage FLOAT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT 
+        contract_address AS contract_hash,
+        CAST(SUM(steps_number) AS BIGINT) AS contract_steps,
+        (CAST(SUM(steps_number) AS FLOAT) * 100.0 / total_steps.total) AS contract_steps_percentage
+    FROM 
+        starkflare_api.account_calls,
+        (SELECT SUM(steps_number) AS total 
+         FROM starkflare_api.account_calls
+         WHERE timestamp >= EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - INTERVAL '7 days'))) AS total_steps
+    WHERE 
+        timestamp >= EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - INTERVAL '7 days'))
+    GROUP BY 
+        contract_address, total_steps.total
+    ORDER BY 
+        contract_steps DESC
+    LIMIT 10;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP FUNCTION IF EXISTS starkflare_api.get_common_data();
+
+CREATE OR REPLACE FUNCTION starkflare_api.get_common_data()
+RETURNS json
+AS $$
+DECLARE
+    user_stats json;
+    top_transactions json;
+    transaction_stats json;
+    top_contracts_by_steps json;
+BEGIN
+    -- Fetch user stats
+    SELECT json_build_object(
+        'unique_users_last_7_days', user_stats.unique_users_last_7_days,
+        'new_users_last_7_days', user_stats.new_users_last_7_days,
+        'lost_users_last_7_days', user_stats.lost_users_last_7_days
+    ) INTO user_stats
+    FROM starkflare_api.get_user_stats() AS user_stats;
+
+    -- Fetch transaction stats
+    SELECT json_build_object(
+        'transactions_count_last_7_days', transaction_stats.transactions_count_last_7_days,
+        'steps_number_last_7_days', transaction_stats.steps_number_last_7_days
+    ) INTO transaction_stats 
+    FROM starkflare_api.get_transaction_stats() AS transaction_stats;
+
+    -- Fetch top contracts by steps stats
+    SELECT json_agg(
+        json_build_object(
+            'contract_hash', contracts.contract_hash,
+            'contract_steps', contracts.contract_steps,
+            'contract_steps_percentage', contracts.contract_steps_percentage
+        )
+    ) INTO top_contracts_by_steps
+    FROM starkflare_api.get_top_contracts_by_steps() AS contracts;
+
+    RETURN json_build_object(
+        'user_stats', user_stats,
+        'transaction_stats', transaction_stats,
+        'top_contracts_by_steps', top_contracts_by_steps
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/database/migrations/004_get_top_contracts_by_steps.up.sql
+++ b/database/migrations/004_get_top_contracts_by_steps.up.sql
@@ -58,9 +58,9 @@ BEGIN
     -- Fetch top contracts by steps stats
     SELECT json_agg(
         json_build_object(
-            'contract_hash', contracts.contract_hash,
-            'contract_steps', contracts.contract_steps,
-            'contract_steps_percentage', contracts.contract_steps_percentage
+            'contract_address', contracts.contract_hash,
+            'steps_number', contracts.contract_steps,
+            'steps_percentage', contracts.contract_steps_percentage
         )
     ) INTO top_contracts_by_steps
     FROM starkflare_api.get_top_contracts_by_steps() AS contracts;


### PR DESCRIPTION
first step for [starkflare-issue-5](https://github.com/walnuthq/starkflare/issues/5)

Added function get_contract_stats and modified get_common_data so it retrieves information about the contracts.
The created function: 
1. Gathers entries from the last 7 days. 
2. Groups by contract and sums the steps per each contract
3. Per each contract divides its steps_number by the sum of the steps_number from the entries of the last seven days

At the end, it returns a table containing the following field of the top 10 contract by steps_number, from the last 7 days:
- contract_hash
- contract_steps
- contract_steps_percentage

and appends the result to get_common_data in json format

Attached there is an image of the process completion

![image](https://github.com/walnuthq/starkflare-indexer/assets/45461757/53aaada1-7a7b-4dbb-9136-058bfbc04ec9)
